### PR TITLE
A few changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Search #
 
-This plugin can help find issue where text searches in bug text, comments, additional informations
+This plugin improves the finding of issues by searching bug text, comments and additional information.
 
 # Requirements #
 

--- a/Search/Search.php
+++ b/Search/Search.php
@@ -37,7 +37,7 @@ class SearchPlugin extends MantisPlugin {
 
 		$this->version = '0.0.4';
 		$this->requires = array(
-			'MantisCore' => '1.2.0',
+			'MantisCore' => '>=1.2, <1.4',
 		);
 
 		$this->author = 'Krasnov Kirill';

--- a/Search/lang/strings_english.txt
+++ b/Search/lang/strings_english.txt
@@ -15,6 +15,6 @@
 
 	$s_plugin_Search = '';
 	$s_plugin_Search_title = 'Search Issues';
-	$s_plugin_Search_description = 'Plugin add more powerfull search engine to MantisBT';
+	$s_plugin_Search_description = 'This plugin adds a more powerful search engine to MantisBT';
 	$s_plugin_Search_search_link = 'Search';
-	$s_plugin_Search_not_found = 'Sorry. For your query nothing found.';
+	$s_plugin_Search_not_found = 'Sorry. Your query returned no results.';

--- a/Search/lang/strings_spanish.txt
+++ b/Search/lang/strings_spanish.txt
@@ -1,0 +1,20 @@
+<?php
+/*
+ Copyright (C) 2009-2014 Kirill Krasnov, kraeg.ru
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+*/
+
+	$s_plugin_Search = '';
+	$s_plugin_Search_title = 'Búsqueda de Incidencias';
+	$s_plugin_Search_description = 'Este accesorio agrega un sistema de búsqueda más efectivo a MantisBT';
+	$s_plugin_Search_search_link = 'Buscar';
+	$s_plugin_Search_not_found = 'Lo siento. Tu búsqueda no generó resultados.';


### PR DESCRIPTION
@Kirill ,
I notice your plugin does not run on Mantis 1.3 due to the version information not allowing this. Some developers create alternate 1.2/1.3 branches. If you are having it together, the version info can be set as follows in this PR. I am not sure if you regularly accept PR's but I would like to collaborate if you'd like. As always, thank you for your contributions.

Added Spanish translation.
Added support for Mantis 1.3 (current version spec did not allow use in Mantis 1.3 without modification).
Fine-tune some of the English text to be more readable.